### PR TITLE
Upgrade to Craft 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     }
   ],
   "require": {
-    "craftcms/cms": ">=3.5"
+    "craftcms/cms": "^4.0.0-alpha.1",
+    "php": "^8.0.2"
   },
   "autoload": {
     "psr-4": {
@@ -36,5 +37,16 @@
     "developerUrl": "https://kffein.com",
     "changelogUrl": "https://raw.githubusercontent.com/kffein/craft-export-csv/master/CHANGELOG.md",
     "class": "kffein\\craftexportcsv\\CraftExportCsv"
+  },
+  "config": {
+    "allow-plugins": {
+      "yiisoft/yii2-composer": true,
+      "craftcms/plugin-installer": true
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "require-dev": {
+    "craftcms/rector": "dev-main"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "kffein/craft-export-csv",
   "description": "A plugin to export entries to CSV files.",
   "type": "craft-plugin",
-  "version": "1.1.0",
+  "version": "4.0.0",
   "keywords": [
     "craft",
     "cms",

--- a/src/CraftExportCsv.php
+++ b/src/CraftExportCsv.php
@@ -60,12 +60,12 @@ class CraftExportCsv extends Plugin
     /**
      * @var bool
      */
-    public $hasCpSection = true;
+    public bool $hasCpSection = true;
 
     /**
      * @var bool
      */
-    public $hasCpSettings = true;
+    public bool $hasCpSettings = true;
 
     // Public Methods
     // =========================================================================
@@ -127,7 +127,7 @@ class CraftExportCsv extends Plugin
         );
     }
 
-    public function getCpNavItem()
+    public function getCpNavItem(): ?array
     {
         $menuItem = parent::getCpNavItem();
         $menuItem['subnav'] = [
@@ -149,7 +149,7 @@ class CraftExportCsv extends Plugin
      *
      * @inheritdoc
      */
-    public function getSettingsResponse()
+    public function getSettingsResponse(): mixed
     {
         $url = UrlHelper::cpUrl('craft-export-csv/settings');
 
@@ -164,7 +164,7 @@ class CraftExportCsv extends Plugin
      *
      * @return \craft\base\Model|null
      */
-    protected function createSettingsModel()
+    protected function createSettingsModel(): ?\craft\base\Model
     {
         return new Settings();
     }

--- a/src/controllers/ReportsController.php
+++ b/src/controllers/ReportsController.php
@@ -33,7 +33,7 @@ class ReportsController extends Controller
     /**
      * @inheritdoc
      */
-    public function init()
+    public function init(): void
     {
         /**
          * For unknow reason Craft Controller set request + response to string

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -35,7 +35,7 @@ class SettingsController extends BaseController
     /**
      * @inheritdoc
      */
-    public function init()
+    public function init(): void
     {
         /**
          * For unknow reason Craft Controller set request + response to string

--- a/src/jobs/CsvRowsJob.php
+++ b/src/jobs/CsvRowsJob.php
@@ -41,7 +41,7 @@ class CsvRowsJob extends BaseJob
     /**
      * @inheritdoc
      */
-    public function execute($queue)
+    public function execute($queue): void
     {
         // Open the file with append as parameters
         $folder = CRAFT_BASE_PATH . '/storage/reports/';
@@ -123,7 +123,7 @@ class CsvRowsJob extends BaseJob
         $this->setProgress($queue, 1);
     }
 
-    protected function defaultDescription()
+    protected function defaultDescription(): ?string
     {
         return 'Exporting Csv';
     }

--- a/src/models/Export.php
+++ b/src/models/Export.php
@@ -54,7 +54,7 @@ class Export extends Model
 
     // Public Methods
     // =========================================================================
-    public function init()
+    public function init(): void
     {
         parent::init();
 
@@ -71,7 +71,7 @@ class Export extends Model
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         return [
             [['sectionHandle', 'filename', 'fields', 'siteId', 'entryStatus'], 'required'],

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -45,7 +45,7 @@ class Settings extends Model
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         return [];
     }

--- a/src/services/Exports.php
+++ b/src/services/Exports.php
@@ -50,7 +50,7 @@ class Exports extends Component
     /**
      * @inheritdoc
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
         $this->settings = CraftExportCsv::$plugin->getSettings();

--- a/src/services/Reports.php
+++ b/src/services/Reports.php
@@ -81,7 +81,7 @@ class Reports extends Component
             return $fields;
         }
 
-        $sectionFields = $section->getEntryTypes()[0]->getFieldLayout()->getFields();
+        $sectionFields = $section->getEntryTypes()[0]->getFieldLayout()->getCustomFields();
 
         foreach ($sectionFields as $field) {
             $fields[$field->handle] = $field->name;

--- a/src/templates/reports/index.twig
+++ b/src/templates/reports/index.twig
@@ -4,25 +4,25 @@
 {% set title  = "reports-label"|t('craft-export-csv') %}
 
 {% block content %}
-
-	{% if exports is defined and exports is empty%}
-		<p>{{ 'no-reports'|t('craft-export-csv') }}</p>
-    	<a href="craft-export-csv/settings" class="btn">{{ 'configure-report'|t('craft-export-csv') }}</a>
-	{% else %}
-		
-		{% for export in exports if export.section is defined %}
-      {{ loop.index > 1 ? '<hr />'}}
-			<div class="reports-section">
-				<div class="export-button-actions">
-		    		<a href="{{ actionUrl('craft-export-csv/reports/generate', { id: export.id }) }}" class="btn submit" >{{ 'generate'|t('craft-export-csv', {sectionName: export.section.name,filename: export.filename }) }}</a>
-		    		<br />
-		    		<a href="{{ actionUrl('craft-export-csv/reports/download', { id: export.id }) }}" class="btn submit {{ export.fileExists ?:'disabled'}}">{{ 'download'|t('craft-export-csv', {filename: export.filename}) }}</a>
-				</div>
-        <div class="last-modified">
-          <label for="last-modified__{{export.id}}">Last updated : </label>
-          <span id="last-modified__{{export.id}}">{{export.dateUpdated is defined and export.dateUpdated is not empty ? craft.exportsService.getDateUpdatedFormated(export.dateUpdated):'none'}}</span>
+  {% if exports is defined and exports is empty%}
+    <p>{{ 'no-reports'|t('craft-export-csv') }}</p>
+      <a href="craft-export-csv/settings" class="btn">{{ 'configure-report'|t('craft-export-csv') }}</a>
+  {% else %}
+    {% for export in exports %}
+      {% if export.section is defined %}
+        {{ loop.index > 1 ? '<hr />'}}
+        <div class="reports-section">
+          <div class="export-button-actions">
+            <a href="{{ actionUrl('craft-export-csv/reports/generate', { id: export.id }) }}" class="btn submit" >{{ 'generate'|t('craft-export-csv', {sectionName: export.section.name,filename: export.filename }) }}</a>
+            <br />
+            <a href="{{ actionUrl('craft-export-csv/reports/download', { id: export.id }) }}" class="btn submit {{ export.fileExists ?:'disabled'}}">{{ 'download'|t('craft-export-csv', {filename: export.filename}) }}</a>
+          </div>
+          <div class="last-modified">
+            <label for="last-modified__{{export.id}}">Last updated : </label>
+            <span id="last-modified__{{export.id}}">{{export.dateUpdated is defined and export.dateUpdated is not empty ? craft.exportsService.getDateUpdatedFormated(export.dateUpdated):'none'}}</span>
+          </div>
         </div>
-      </div>
-		{% endfor %}
-	{% endif %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
 {% endblock %}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -29,7 +29,7 @@
         instructions: 'numberOfRows-instructions'|t('craft-export-csv'),
         id: 'numberOfRows',
         name: 'settings[numberOfRows]',
-        
+
         size:3
     })}}
 
@@ -45,7 +45,7 @@
         label: 'sites-handle-label'|t('craft-export-csv'),
         id: 'sectionHandle',
         name: 'settings[siteId]',
-        
+
         options: sitesOptions,
     })}}
 
@@ -63,7 +63,7 @@
         id: 'filename',
         name: 'settings[filename]',
         required:true,
-        
+
     })}}
 
     {{ forms.editableTableField({
@@ -86,6 +86,9 @@
                 type: 'text',
             }
         },
+        allowAdd: true,
+        allowReorder: true,
+        allowDelete: true,
     })}}
 
     <div class="heading">
@@ -105,7 +108,7 @@
             <p>{{ export.filename }}</p>
             <a href="{{ actionUrl('craft-export-csv/settings/delete-export', { id: export.id }) }}" class="btn submit" >{{ 'delete'|t('craft-export-csv') }}</a>
             </div>
-            
+
         {% endfor %}
     </div>
 

--- a/src/translations/en/craft-export-csv.php
+++ b/src/translations/en/craft-export-csv.php
@@ -49,5 +49,5 @@ return [
     'no-reports' => 'No report has been configured.',
     'configure-report' => 'Configure a report',
     'no-result' => 'No entry to download.',
-    'reports-list' => 'List of report',
+    'reports-list' => 'List of reports',
 ];


### PR DESCRIPTION
We upgrade `kffein/craft-export-csv` to work with craft 4 by using `craftcms/rector`, and make some minor fixes and standardisation.

## Work involved in this pull request

* Convert to craft-4 using [craftcms/rector](https://github.com/craftcms/rector)
* Added a `.editorconfig` and standardised formatting in the twig templates (2 space indentation)
* Fix typo (`List of report` to `List of reports`)
* Ensure editableTableField is visible in craft-4
* 
## How we upgraded to craft 4

First, run up a docker container:

```
docker run -it --rm -v "$PWD":/app craftcms/php-fpm:8.1-dev /bin/ash
```

Then, update as [per the instructions](https://github.com/craftcms/rector).
