### PR TITLE
task/improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.1 - 2022-12-14
+### Fix
+- Ensure composer.json version matches tag
+
 ## 4.1.0 - 2022-12-14
 ### Added
 - Allow editing of a previously-created export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.0 - 2022-12-14
+### Added
+- Allow editing of a previously-created export
+- Allow an export to be duplicated
+- Include a name for the export and reformat reports screen
+- Allow empty field values
+- Allow exported entries to be expired
+### Fix
+- Assignment operator should be equality operator
+
+## 4.0.0 - 2022-12-11
+### Added
+- Convert to craft-4 using craftcms/rector
+- Add .editorconfig
+- Bump to 4.0.0
+### Fix
+- Fix typo
+- Ensure editableTableField is visible in craft-4
+-  Standardise formatting
+
 ## 1.1.1 - 2020-11-16
 ### Added
 - Add support for Craft 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.2.0 - 2022-12-19
+### Added
+- Allow use of {batch} in filename
+
 ## 4.1.1 - 2022-12-14
 ### Fix
 - Ensure composer.json version matches tag

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "kffein/craft-export-csv",
   "description": "A plugin to export entries to CSV files.",
   "type": "craft-plugin",
-  "version": "4.0.0",
+  "version": "4.1.1",
   "keywords": [
     "craft",
     "cms",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "kffein/craft-export-csv",
   "description": "A plugin to export entries to CSV files.",
   "type": "craft-plugin",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "keywords": [
     "craft",
     "cms",

--- a/src/assetbundles/craftexportcsv/dist/css/CraftExportCsv.css
+++ b/src/assetbundles/craftexportcsv/dist/css/CraftExportCsv.css
@@ -10,7 +10,19 @@
  * @since     1.0.1
  */
 
- .reports-section{
+.flex {
+  display: flex;
+}
+
+.space-between {
+  justify-content: space-between;
+}
+
+.align-start {
+  align-items: flex-start;
+}
+
+.reports-section{
   display: flex;
   justify-content: space-between;
 }

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -86,6 +86,17 @@ class SettingsController extends BaseController
             ];
         }, $status_list);
 
+        // If the user has selected a particular export, find the details
+        $selectedExport = null;
+        $id = Craft::$app->request->getParam('id');
+        if ($id) {
+          foreach ($this->settings->exports as $export) {
+            if ($id = $export['id']) {
+              $selectedExport = $export;
+            }
+          }
+        }
+
         return $this->renderTemplate(
             'craft-export-csv/settings',
             [
@@ -94,6 +105,7 @@ class SettingsController extends BaseController
                 'sitesOptions' => $sitesOptions,
                 'statusOptions' => $statusOptions,
                 'fieldTypeOptions' => $this->plugin->reportsService->getFieldTypeOptions(),
+                'selectedExport' => $selectedExport,
             ]
         );
     }
@@ -138,12 +150,26 @@ class SettingsController extends BaseController
             return null;
         }
 
-        // Create export from model and set all required value.
-        $newExport = new Export();
-        $newExport->setAttributes($exportValue);
+        $id = Craft::$app->request->getParam('id');
 
-        // Add new export to settings array
-        $this->settings->exports[] = $newExport;
+        if ($id) {
+          // Update existing export using model
+          $export = $this->plugin->exportsService->getExportById($id);
+          $existingExport = new Export();
+          $existingExport->setAttributes($exportValue);
+          foreach ($this->settings->exports as $key => $export) {
+            if ($id = $export['id']) {
+              $this->settings->exports[$key] = $existingExport;
+            }
+          }
+        } else {
+          // Create export from model and set all required value.
+          $newExport = new Export();
+          $newExport->setAttributes($exportValue);
+          // Add new export to settings array
+          $this->settings->exports[] = $newExport;
+        }
+
         if (!Craft::$app->getPlugins()->savePluginSettings($this->plugin, $this->settings->exports)) {
             Craft::$app->getSession()->setError(Craft::t('app', 'Couldn’t save plugin settings.'));
 
@@ -157,7 +183,8 @@ class SettingsController extends BaseController
 
         Craft::$app->getSession()->setNotice(Craft::t('app', 'Plugin settings updated.'));
 
-        return $this->redirectToPostedUrl();
+        // return $this->redirectToPostedUrl();
+        return $this->redirect('craft-export-csv/settings');
     }
 
     /**

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -86,6 +86,15 @@ class SettingsController extends BaseController
             ];
         }, $status_list);
 
+        $expire_entries_list = ['Expire exported entries'];
+
+        $expireEntriesOptions = array_map(function ($status) {
+            return [
+                'label' => $status,
+                'value' => $status,
+            ];
+        }, $expire_entries_list);
+
         // If the user has selected a particular export, find the details
         $selectedExport = null;
         $id = Craft::$app->request->getParam('id');
@@ -105,6 +114,7 @@ class SettingsController extends BaseController
                 'sectionsOptions' => $sectionsOptions,
                 'sitesOptions' => $sitesOptions,
                 'statusOptions' => $statusOptions,
+                'expireEntriesOptions' => $expireEntriesOptions,
                 'fieldTypeOptions' => $this->plugin->reportsService->getFieldTypeOptions(),
                 'selectedExport' => $selectedExport,
             ]

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -89,6 +89,7 @@ class SettingsController extends BaseController
         // If the user has selected a particular export, find the details
         $selectedExport = null;
         $id = Craft::$app->request->getParam('id');
+
         if ($id) {
           foreach ($this->settings->exports as $export) {
             if ($id = $export['id']) {
@@ -150,7 +151,7 @@ class SettingsController extends BaseController
             return null;
         }
 
-        $id = Craft::$app->request->getParam('id');
+        $id = $exportValue['id'] ?? null;
 
         if ($id) {
           // Update existing export using model
@@ -158,7 +159,7 @@ class SettingsController extends BaseController
           $existingExport = new Export();
           $existingExport->setAttributes($exportValue);
           foreach ($this->settings->exports as $key => $export) {
-            if ($id = $export['id']) {
+            if ($id == $export['id']) {
               $this->settings->exports[$key] = $existingExport;
             }
           }

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -188,6 +188,27 @@ class SettingsController extends BaseController
     }
 
     /**
+     * Duplicate an export
+     *
+     * @return null|\yii\web\Response
+     * @throws BadRequestHttpException
+     * @throws \yii\db\Exception
+     */
+    public function actionDuplicateExport()
+    {
+        $id = Craft::$app->request->getParam('id');
+
+        $this->plugin->exportsService->duplicateExportById($id);
+
+        if (!Craft::$app->getPlugins()->savePluginSettings($this->plugin, $this->settings->exports)) {
+            Craft::$app->getSession()->setError(Craft::t('app', 'Couldn’t save plugin settings.'));
+        } else {
+            Craft::$app->getSession()->setNotice(Craft::t('app', 'Plugin settings updated.'));
+        }
+        return $this->redirect('craft-export-csv/settings');
+    }
+
+    /**
      * Delete an export from array
      *
      * @return null|\yii\web\Response

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -92,7 +92,7 @@ class SettingsController extends BaseController
 
         if ($id) {
           foreach ($this->settings->exports as $export) {
-            if ($id = $export['id']) {
+            if ($id == $export['id']) {
               $selectedExport = $export;
             }
           }

--- a/src/jobs/CsvRowsJob.php
+++ b/src/jobs/CsvRowsJob.php
@@ -83,7 +83,9 @@ class CsvRowsJob extends BaseJob
                     case CraftExportCsv::FIELD_TYPE_HANDLE:
                     default:
                         // Some field data contains different object.
-                        if ($entry->{$field['value']} instanceof CategoryQuery || $entry->{$field['value']} instanceof EntryQuery) {
+                        if (!$field['value']) {
+                          $entryData[] = '';
+                        } elseif ($entry->{$field['value']} instanceof CategoryQuery || $entry->{$field['value']} instanceof EntryQuery) {
                             $entryData[] = CraftExportCsv::getInstance()->reportsService->getTitles($entry->{$field['value']}->all());
                         } elseif (is_object($entry->{$field['value']}) && get_class($entry->{$field['value']}) === 'craft\elements\db\AssetQuery') {
                             $entryData[] = $entry->{$field['value']}->one() !== null ? $entry->{$field['value']}->one()->url : null;

--- a/src/jobs/CsvRowsJob.php
+++ b/src/jobs/CsvRowsJob.php
@@ -134,6 +134,7 @@ class CsvRowsJob extends BaseJob
         // If it's the last job in the queue, we update the export date in the settings
         if ($this->last) {
             CraftExportCsv::getInstance()->exportsService->updateExportDate($this->export['id']);
+            CraftExportCsv::getInstance()->exportsService->updateExportBatch($this->export['id']);
         }
 
         // Job done

--- a/src/models/Export.php
+++ b/src/models/Export.php
@@ -35,6 +35,7 @@ class Export extends Model
     public $siteId;
     public $entryStatus;
     public $expireEntries;
+    public $batch;
 
     /**
      * Temporary porperty of the converted field name everytime the csv is generated.
@@ -78,7 +79,7 @@ class Export extends Model
         return [
             [['name', 'sectionHandle', 'filename', 'fields', 'siteId', 'entryStatus', 'expireEntries'], 'required'],
             [['name', 'sectionHandle', 'filename'], 'string'],
-            [['numberOfRows'], 'number'],
+            [['numberOfRows', 'batch'], 'number'],
         ];
     }
 }

--- a/src/models/Export.php
+++ b/src/models/Export.php
@@ -34,6 +34,7 @@ class Export extends Model
     public $filename = '{section-handle}-{timestamp}.csv';
     public $siteId;
     public $entryStatus;
+    public $expireEntries;
 
     /**
      * Temporary porperty of the converted field name everytime the csv is generated.
@@ -75,7 +76,7 @@ class Export extends Model
     public function rules(): array
     {
         return [
-            [['name', 'sectionHandle', 'filename', 'fields', 'siteId', 'entryStatus'], 'required'],
+            [['name', 'sectionHandle', 'filename', 'fields', 'siteId', 'entryStatus', 'expireEntries'], 'required'],
             [['name', 'sectionHandle', 'filename'], 'string'],
             [['numberOfRows'], 'number'],
         ];

--- a/src/models/Export.php
+++ b/src/models/Export.php
@@ -29,6 +29,7 @@ class Export extends Model
      * @var string
      */
     public $id;
+    public $name;
     public $sectionHandle;
     public $filename = '{section-handle}-{timestamp}.csv';
     public $siteId;
@@ -74,8 +75,8 @@ class Export extends Model
     public function rules(): array
     {
         return [
-            [['sectionHandle', 'filename', 'fields', 'siteId', 'entryStatus'], 'required'],
-            [['sectionHandle', 'filename'], 'string'],
+            [['name', 'sectionHandle', 'filename', 'fields', 'siteId', 'entryStatus'], 'required'],
+            [['name', 'sectionHandle', 'filename'], 'string'],
             [['numberOfRows'], 'number'],
         ];
     }

--- a/src/services/Exports.php
+++ b/src/services/Exports.php
@@ -90,7 +90,7 @@ class Exports extends Component
             if ($export['id'] == $id) {
                 // Create export from model and set all required value.
                 $exportValue = $this->settings->exports[$key];
-                $exportValue['dateUpdated'] = time();
+                $exportValue['id'] = null;
                 $newExport = new Export();
                 $newExport->setAttributes($exportValue);
                 // Add new export to settings array

--- a/src/services/Exports.php
+++ b/src/services/Exports.php
@@ -11,6 +11,7 @@
 namespace kffein\craftexportcsv\services;
 
 use kffein\craftexportcsv\CraftExportCsv;
+use kffein\craftexportcsv\models\Export;
 
 use Craft;
 use craft\base\Component;
@@ -42,7 +43,7 @@ class Exports extends Component
      */
     public $plugin;
 
-    
+
 
     // Public Methods
     // =========================================================================
@@ -77,6 +78,30 @@ class Exports extends Component
     }
 
     /**
+     * Duplicate from settings an export by id WITHOUT SAVING
+     * @param string $id
+     * @return bool
+     */
+    public function duplicateExportById($id)
+    {
+        $oneDuplicated = false;
+        // Loop all export and duplicate from settings by keys found
+        foreach ($this->settings->exports as $key => $export) {
+            if ($export['id'] == $id) {
+                // Create export from model and set all required value.
+                $exportValue = $this->settings->exports[$key];
+                $exportValue['dateUpdated'] = time();
+                $newExport = new Export();
+                $newExport->setAttributes($exportValue);
+                // Add new export to settings array
+                $this->settings->exports[] = $newExport;
+                $oneDuplicated = true;
+            }
+        }
+        return $oneDuplicated;
+    }
+
+    /**
      * Delete from settings an export by id WITHOUT SAVING
      * @param string $id
      * @return bool
@@ -105,7 +130,7 @@ class Exports extends Component
                 $this->settings->exports[$key]['dateUpdated'] = time();
             }
         }
-        
+
         Craft::$app->getPlugins()->savePluginSettings($this->plugin, $this->settings->exports);
     }
 

--- a/src/services/Exports.php
+++ b/src/services/Exports.php
@@ -157,4 +157,17 @@ class Exports extends Component
         }
         Craft::$app->getPlugins()->savePluginSettings($this->plugin, $this->settings->exports);
     }
+    /**
+     * Update batch if report has been generated
+     * @param string $id
+     */
+    public function updateExportBatch($id)
+    {
+        foreach ($this->settings->exports as $key => $export) {
+            if ($export['id'] == $id) {
+                $this->settings->exports[$key]['batch'] = intval($this->settings->exports[$key]['batch']) + 1;
+            }
+        }
+        Craft::$app->getPlugins()->savePluginSettings($this->plugin, $this->settings->exports);
+    }
 }

--- a/src/services/Reports.php
+++ b/src/services/Reports.php
@@ -54,12 +54,15 @@ class Reports extends Component
         $now = new DateTime();
 
         $filename = $exportSettings['filename'];
-        $filename = $filename = preg_replace('/{timestamp}/', $now->getTimestamp(), $filename);
-        $filename = $filename = preg_replace('/{Y}/', $now->format('Y'), $filename);
-        $filename = $filename = preg_replace('/{m}/', $now->format('m'), $filename);
-        $filename = $filename = preg_replace('/{d}/', $now->format('d'), $filename);
-        $filename = $filename = preg_replace('/{H}/', $now->format('H'), $filename);
-        $filename = $filename = preg_replace('/{i}/', $now->format('i'), $filename);
+        $filename = preg_replace('/{timestamp}/', $now->getTimestamp(), $filename);
+        $filename = preg_replace('/{Y}/', $now->format('Y'), $filename);
+        $filename = preg_replace('/{m}/', $now->format('m'), $filename);
+        $filename = preg_replace('/{d}/', $now->format('d'), $filename);
+        $filename = preg_replace('/{H}/', $now->format('H'), $filename);
+        $filename = preg_replace('/{i}/', $now->format('i'), $filename);
+        if ($exportSettings['batch']) {
+          $filename = preg_replace('/{batch}/', $exportSettings['batch'], $filename);
+        }
         if ($exportSettings['sectionHandle']) {
             $filename = preg_replace('/{section-handle}/', $exportSettings['sectionHandle'], $filename);
         }

--- a/src/templates/reports/index.twig
+++ b/src/templates/reports/index.twig
@@ -11,15 +11,18 @@
     {% for export in exports %}
       {% if export.section is defined %}
         {{ loop.index > 1 ? '<hr />'}}
+        <h2>{{ 'generate-heading'|t('craft-export-csv', {sectionName: export.section.name }) }}</h2>
         <div class="reports-section">
-          <div class="export-button-actions">
-            <a href="{{ actionUrl('craft-export-csv/reports/generate', { id: export.id }) }}" class="btn submit" >{{ 'generate'|t('craft-export-csv', {sectionName: export.section.name,filename: export.filename }) }}</a>
-            <br />
-            <a href="{{ actionUrl('craft-export-csv/reports/download', { id: export.id }) }}" class="btn submit {{ export.fileExists ?:'disabled'}}">{{ 'download'|t('craft-export-csv', {filename: export.filename}) }}</a>
+          <div class="flex align-start">
+            <p><a href="{{ url('craft-export-csv/settings', { id: export.id }) }}">{{ export.name }}</a></p>
+            <div class="last-modified">
+              <label for="last-modified__{{export.id}}">Last export: </label>
+              <span id="last-modified__{{export.id}}">{{export.dateUpdated is defined and export.dateUpdated is not empty ? craft.exportsService.getDateUpdatedFormated(export.dateUpdated):'none'}}</span>
+            </div>
           </div>
-          <div class="last-modified">
-            <label for="last-modified__{{export.id}}">Last updated : </label>
-            <span id="last-modified__{{export.id}}">{{export.dateUpdated is defined and export.dateUpdated is not empty ? craft.exportsService.getDateUpdatedFormated(export.dateUpdated):'none'}}</span>
+          <div class="export-button-actions">
+            <a title="{{ 'generate'|t('craft-export-csv', {filename: export.filename }) }}" href="{{ actionUrl('craft-export-csv/reports/generate', { id: export.id }) }}" class="btn submit" >generate</a>
+            <a title="{{ 'download'|t('craft-export-csv', {filename: export.filename }) }}" href="{{ actionUrl('craft-export-csv/reports/download', { id: export.id }) }}" class="btn submit {{ export.fileExists ?:'disabled'}}">download</a>
           </div>
         </div>
       {% endif %}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -112,7 +112,10 @@
                 <p>{{ export.sectionHandle }}</p>
                 <p><a href="{{ url('craft-export-csv/settings', { id: export.id }) }}">{{ export.filename }}</a></p>
               </div>
-              <a href="{{ actionUrl('craft-export-csv/settings/delete-export', { id: export.id }) }}" class="btn submit" >{{ 'delete'|t('craft-export-csv') }}</a>
+              <div class="flex">
+                <a href="{{ actionUrl('craft-export-csv/settings/duplicate-export', { id: export.id }) }}" class="btn submit" >{{ 'duplicate'|t('craft-export-csv') }}</a>
+                <a href="{{ actionUrl('craft-export-csv/settings/delete-export', { id: export.id }) }}" class="btn submit" >{{ 'delete'|t('craft-export-csv') }}</a>
+              </div>
             </div>
 
         {% endfor %}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -30,7 +30,8 @@
         id: 'numberOfRows',
         name: 'settings[numberOfRows]',
 
-        size:3
+        size:3,
+        value: selectedExport['numberOfRows'] ?? null,
     })}}
 
     {{ forms.selectField({
@@ -39,22 +40,23 @@
         id: 'siteId',
         name: 'settings[sectionHandle]',
         options: sectionsOptions,
+        value: selectedExport['sectionHandle'] ?? null,
     })}}
 
     {{ forms.selectField({
         label: 'sites-handle-label'|t('craft-export-csv'),
         id: 'sectionHandle',
         name: 'settings[siteId]',
-
         options: sitesOptions,
+        value: selectedExport['siteId'] ?? null,
     })}}
 
     {{ forms.checkboxSelectField({
         label: 'entryStatus-handle-label'|t('craft-export-csv'),
         id: 'entryStatus',
         name: 'settings[entryStatus]',
-        values: ['Enabled', 'Live'],
-        options: statusOptions
+        values: selectedExport['entryStatus'] ?? ['Enabled', 'Live'],
+        options: statusOptions,
     }) }}
 
     {{ forms.textField({
@@ -62,6 +64,7 @@
         instructions: 'filename-instructions'|t('craft-export-csv'),
         id: 'filename',
         name: 'settings[filename]',
+        value: selectedExport['filename'] ?? null,
         required:true,
 
     })}}
@@ -86,6 +89,7 @@
                 type: 'text',
             }
         },
+        rows: selectedExport['fields'] ?? null,
         allowAdd: true,
         allowReorder: true,
         allowDelete: true,
@@ -103,22 +107,28 @@
     <div id="reports-list" class="field">
         {% for export in settings.exports %}
             <hr/>
-            <div>
-            <p>{{ export.sectionHandle }}</p>
-            <p>{{ export.filename }}</p>
-            <a href="{{ actionUrl('craft-export-csv/settings/delete-export', { id: export.id }) }}" class="btn submit" >{{ 'delete'|t('craft-export-csv') }}</a>
+            <div class="flex space-between">
+              <div class="flex">
+                <p>{{ export.sectionHandle }}</p>
+                <p><a href="{{ url('craft-export-csv/settings', { id: export.id }) }}">{{ export.filename }}</a></p>
+              </div>
+              <a href="{{ actionUrl('craft-export-csv/settings/delete-export', { id: export.id }) }}" class="btn submit" >{{ 'delete'|t('craft-export-csv') }}</a>
             </div>
 
         {% endfor %}
     </div>
 
     <style type="text/css">
-        #reports-list a{
-            float:right;
+        #reports-list .flex {
+          display: flex;
+        }
+        #reports-list .space-between {
+          justify-content: space-between;
+        }
+        #reports-list .btn{
             margin: 15px;
         }
         #reports-list p{
-            float:left;
             margin: 21px !important;
             color: #8f98a3;
         }

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -79,6 +79,15 @@
         required:true,
     })}}
 
+    {{ forms.checkboxSelectField({
+        label: 'expireEntries-label'|t('craft-export-csv'),
+        instructions: 'expireEntries-instructions'|t('craft-export-csv'),
+        id: 'expireEntries',
+        name: 'settings[expireEntries]',
+        values: selectedExport['expireEntries'] ?? ['Expire exported entries'],
+        options: expireEntriesOptions,
+    }) }}
+
     {{ forms.editableTableField({
         label: 'fields-label'|t('craft-export-csv'),
         instructions: 'fields-instructions'|t('craft-export-csv'),

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -22,14 +22,25 @@
 
 {% block content %}
     <input type="hidden" name="action" value="craft-export-csv/settings/save-settings">
+    {% if selectedExport['id'] ?? null %}
+      <input type="hidden" name="settings[id]" value="{{ selectedExport['id'] }}">
+    {% endif %}
     {{ redirectInput('craft-export-csv/settings') }}
+
+    {{ forms.textField({
+        label: 'name-label'|t('craft-export-csv'),
+        instructions: 'name-instructions'|t('craft-export-csv'),
+        id: 'name',
+        name: 'settings[name]',
+        value: selectedExport['name'] ?? null,
+        required:true,
+    })}}
 
     {{ forms.textField({
         label: 'numberOfRows-label'|t('craft-export-csv'),
         instructions: 'numberOfRows-instructions'|t('craft-export-csv'),
         id: 'numberOfRows',
         name: 'settings[numberOfRows]',
-
         size:3,
         value: selectedExport['numberOfRows'] ?? null,
     })}}
@@ -66,7 +77,6 @@
         name: 'settings[filename]',
         value: selectedExport['filename'] ?? null,
         required:true,
-
     })}}
 
     {{ forms.editableTableField({
@@ -109,8 +119,9 @@
             <hr/>
             <div class="flex space-between">
               <div class="flex">
+                <p><a href="{{ url('craft-export-csv/settings', { id: export.id }) }}">{{ export.name }}</a></p>
                 <p>{{ export.sectionHandle }}</p>
-                <p><a href="{{ url('craft-export-csv/settings', { id: export.id }) }}">{{ export.filename }}</a></p>
+                <p>{{ export.filename }}</p>
               </div>
               <div class="flex">
                 <a href="{{ actionUrl('craft-export-csv/settings/duplicate-export', { id: export.id }) }}" class="btn submit" >{{ 'duplicate'|t('craft-export-csv') }}</a>
@@ -122,10 +133,11 @@
     </div>
 
     <style type="text/css">
-        #reports-list .flex {
+        .flex {
           display: flex;
         }
-        #reports-list .space-between {
+
+        .space-between {
           justify-content: space-between;
         }
         #reports-list .btn{

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -25,6 +25,7 @@
     {% if selectedExport['id'] ?? null %}
       <input type="hidden" name="settings[id]" value="{{ selectedExport['id'] }}">
     {% endif %}
+    <input type="hidden" name="settings[batch]" value="{{ selectedExport['batch'] ?? '0' }}">
     {{ redirectInput('craft-export-csv/settings') }}
 
     {{ forms.textField({

--- a/src/translations/en/craft-export-csv.php
+++ b/src/translations/en/craft-export-csv.php
@@ -37,7 +37,7 @@ return [
     'name-label' => 'Name of the export',
     'name-instructions' => 'Choose a descriptive name for the export',
     'filename-label' => 'File Name',
-    'filename-instructions' => 'Keys available: {timestamp}, {Y}, {d}, {m}, {H}, {i}, {section-handle}',
+    'filename-instructions' => 'Keys available: {batch}, {timestamp}, {Y}, {d}, {m}, {H}, {i}, {section-handle}',
     'fields-label' => 'Columns',
     'fields-instructions' => 'Describe columns to export.',
     'field-name' => 'Column Title',

--- a/src/translations/en/craft-export-csv.php
+++ b/src/translations/en/craft-export-csv.php
@@ -31,6 +31,8 @@ return [
     'section-handle-label' => 'Entries to export',
     'sites-handle-label' => 'Sites',
     'entryStatus-handle-label' => 'Entries status',
+    'expireEntries-label' => 'Expire exported entries',
+    'expireEntries-instructions' => 'Choose whether to set the status of entries to expired once they\'ve been exported.',
     'section-handle-instructions' => 'Choose the entry type you want to export.',
     'name-label' => 'Name of the export',
     'name-instructions' => 'Choose a descriptive name for the export',

--- a/src/translations/en/craft-export-csv.php
+++ b/src/translations/en/craft-export-csv.php
@@ -32,6 +32,8 @@ return [
     'sites-handle-label' => 'Sites',
     'entryStatus-handle-label' => 'Entries status',
     'section-handle-instructions' => 'Choose the entry type you want to export.',
+    'name-label' => 'Name of the export',
+    'name-instructions' => 'Choose a descriptive name for the export',
     'filename-label' => 'File Name',
     'filename-instructions' => 'Keys available: {timestamp}, {Y}, {d}, {m}, {H}, {i}, {section-handle}',
     'fields-label' => 'Columns',
@@ -44,8 +46,9 @@ return [
     'field-value' => 'Value',
 
     // Reports
-    'generate' => 'Generate file : {filename} for section : {sectionName}',
-    'download' => 'Download {filename}',
+    'generate-heading' => 'Generate export for section: {sectionName}',
+    'generate' => 'Generate csv file {filename}',
+    'download' => 'Download csv file {filename}',
     'no-reports' => 'No report has been configured.',
     'configure-report' => 'Configure a report',
     'no-result' => 'No entry to download.',

--- a/src/translations/fr/craft-export-csv.php
+++ b/src/translations/fr/craft-export-csv.php
@@ -31,6 +31,8 @@ return [
     'section-handle-label' => 'Entrée à exporter',
     'sites-handle-label' => 'Sites',
     'entryStatus-handle-label' => 'Status des entrées',
+    'expireEntries-label' => 'Faire expirer les entrées exportées',
+    'expireEntries-instructions' => 'Choisissez si vous souhaitez définir le statut des entrées sur expiré une fois qu\'elles ont été exportées.',
     'section-handle-instructions' => 'Sélectionnez le type d’entrée que vous souhaitez exporter.',
     'name-label' => 'Nom de l\'export',
     'name-instructions' => 'Choisir un nom descriptif pour l\'export',

--- a/src/translations/fr/craft-export-csv.php
+++ b/src/translations/fr/craft-export-csv.php
@@ -32,6 +32,8 @@ return [
     'sites-handle-label' => 'Sites',
     'entryStatus-handle-label' => 'Status des entrées',
     'section-handle-instructions' => 'Sélectionnez le type d’entrée que vous souhaitez exporter.',
+    'name-label' => 'Nom de l\'export',
+    'name-instructions' => 'Choisir un nom descriptif pour l\'export',
     'filename-label' => 'Nom du fichier',
     'filename-instructions' => 'Clés disponibiles: {timestamp}, {Y}, {d}, {m}, {H}, {i}, {section-handle}',
     'fields-label' => 'Colonnes',
@@ -44,8 +46,9 @@ return [
     'field-value' => 'Valeur',
 
     // Reports
-    'generate' => 'Génerer le fichier {filename} de la section : {sectionName}',
-    'download' => 'Télécharger le fichier {filename}',
+    'generate-heading' => 'Générer un export pour la section: {sectionName}',
+    'generate' => 'Générer le fichier csv {filename}',
+    'download' => 'Télécharger le fichier csv {filename}',
     'no-reports' => 'Aucun rapport configuré.',
     'configure-report' => 'Configurer un rapport',
     'no-result' => 'Aucune entrée à télécharger',

--- a/src/translations/fr/craft-export-csv.php
+++ b/src/translations/fr/craft-export-csv.php
@@ -37,7 +37,7 @@ return [
     'name-label' => 'Nom de l\'export',
     'name-instructions' => 'Choisir un nom descriptif pour l\'export',
     'filename-label' => 'Nom du fichier',
-    'filename-instructions' => 'Clés disponibiles: {timestamp}, {Y}, {d}, {m}, {H}, {i}, {section-handle}',
+    'filename-instructions' => 'Clés disponibiles: {batch}, {timestamp}, {Y}, {d}, {m}, {H}, {i}, {section-handle}',
     'fields-label' => 'Colonnes',
     'fields-instructions' => 'Décrivez les colonnes à exporter.',
     'field-name' => 'Titre de la colonne',


### PR DESCRIPTION
We add a number of improvements:

* Allow editing of a previously-created export
* Allow exported entries to be expired
* Allow an export to be duplicated
* Include a name for the export and reformat reports screen
* Allow empty field values
* Allow use of `{batch}` in filename